### PR TITLE
Fixing installation of Supercronic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,12 +62,13 @@ RUN chmod +x /tini
 RUN SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.9/supercronic-linux-amd64 \
  && SUPERCRONIC=supercronic-linux-amd64 \
  && SUPERCRONIC_SHA1SUM=5ddf8ea26b56d4a7ff6faecdd8966610d5cb9d85 \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends curl \
  && curl -fsSLO "$SUPERCRONIC_URL" \
  && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
  && chmod +x "$SUPERCRONIC" \
  && sudo mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
- && sudo ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic;
-
+ && sudo ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic
 
 COPY utils/generate_cron.php /usr/local/bin/generate_cron.php
 COPY utils/startup_commands.php /usr/local/bin/startup_commands.php

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,8 +67,8 @@ RUN SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.
  && curl -fsSLO "$SUPERCRONIC_URL" \
  && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
  && chmod +x "$SUPERCRONIC" \
- && sudo mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
- && sudo ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic
+ && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
+ && ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic
 
 COPY utils/generate_cron.php /usr/local/bin/generate_cron.php
 COPY utils/startup_commands.php /usr/local/bin/startup_commands.php

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,16 +59,14 @@ RUN chmod +x /tini
 # | Supercronic is a drop-in replacement for cron (for containers).
 # |
 
-RUN if [ -n "$INSTALL_CRON" ]; then \
- SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.9/supercronic-linux-amd64 \
+RUN SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.9/supercronic-linux-amd64 \
  && SUPERCRONIC=supercronic-linux-amd64 \
  && SUPERCRONIC_SHA1SUM=5ddf8ea26b56d4a7ff6faecdd8966610d5cb9d85 \
  && curl -fsSLO "$SUPERCRONIC_URL" \
  && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
  && chmod +x "$SUPERCRONIC" \
  && sudo mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
- && sudo ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic; \
- fi;
+ && sudo ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic;
 
 
 COPY utils/generate_cron.php /usr/local/bin/generate_cron.php

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.
  && SUPERCRONIC=supercronic-linux-amd64 \
  && SUPERCRONIC_SHA1SUM=5ddf8ea26b56d4a7ff6faecdd8966610d5cb9d85 \
  && apt-get update \
- && apt-get install -y --no-install-recommends curl \
+ && apt-get install -y --no-install-recommends ca-certificates curl \
  && curl -fsSLO "$SUPERCRONIC_URL" \
  && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
  && chmod +x "$SUPERCRONIC" \


### PR DESCRIPTION
This PR is an attempt to fix the following error when trying to use the CRON features:

```
Cron is not available in this image. If you are using the thecodingmachine/php "slim" variant, do not forget to add "ARG INSTALL_CRON=1" in your Dockerfile. Check the documentation for more details.
```