### PR TITLE
Switching to Oracle Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 [![Build Status](https://travis-ci.org/thecodingmachine/docker-images-mysql.svg?branch=master)](https://travis-ci.org/thecodingmachine/docker-images-mysql)
 
-# WORK IN PROGRESS - NOT READY FOR USE YET
-
 # Highly configurable MySQL images for Docker
 
 This repository contains a set of **developer-friendly** MySQL images for Docker.
@@ -13,10 +11,12 @@ This repository contains a set of **developer-friendly** MySQL images for Docker
 
 ## Images
 
-| Name                                                                    | MySQL version                |  Size 
-|-------------------------------------------------------------------------|------------------------------|------
-| [thecodingmachine/mysql:5.7-v1](https://github.com/thecodingmachine/docker-images-mysql/blob/master/Dockerfile)             | `5.7.x` | [![](https://images.microbadger.com/badges/image/thecodingmachine/mysql:5.7-v1.svg)](https://microbadger.com/images/thecodingmachine/mysql:5.7-v1)
-| [thecodingmachine/mysql:8.0-v1](https://github.com/thecodingmachine/docker-images-mysql/blob/master/Dockerfile)             | `8.0.x` | [![](https://images.microbadger.com/badges/image/thecodingmachine/mysql:8.0-v1.svg)](https://microbadger.com/images/thecodingmachine/mysql:8.0-v1)
+| Name                                                                                                            | MySQL version | Base distribution | Architectures 
+|-----------------------------------------------------------------------------------------------------------------|---------------|-------------------|----------------
+| [thecodingmachine/mysql:5.7-v2](https://github.com/thecodingmachine/docker-images-mysql/blob/master/Dockerfile) | `5.7.x`       | Oracle Linux      | AMD64 / ARM64 
+| [thecodingmachine/mysql:8.0-v2](https://github.com/thecodingmachine/docker-images-mysql/blob/master/Dockerfile) | `8.0.x`       | Oracle Linux      | AMD64 / ARM64
+| [thecodingmachine/mysql:5.7-v1](https://github.com/thecodingmachine/docker-images-mysql/blob/master/Dockerfile) | `5.7.x`       | Debian Linux      | AMD64
+| [thecodingmachine/mysql:8.0-v1](https://github.com/thecodingmachine/docker-images-mysql/blob/master/Dockerfile) | `8.0.x`       | Debian Linux      | AMD64
 
 Note: we do not tag patch releases of MySQL, only minor versions. You will find one image for MySQL 5.7, one for MySQL 8.0, 
 but no tagged image for MySQL 5.7.12. This is because we believe you have no valid reason to ask explicitly for 5.7.12.

--- a/build-and-test.sh
+++ b/build-and-test.sh
@@ -3,7 +3,7 @@
 set -xe
 
 # Let's build the "slim" image.
-docker buildx build --platform=linux/amd64 --load -t thecodingmachine/mysql:${MYSQL_VERSION}-v1 --build-arg MYSQL_VERSION=${MYSQL_VERSION} .
+docker buildx build --platform=linux/amd64 --load -t thecodingmachine/mysql:${MYSQL_VERSION}-v2 --build-arg MYSQL_VERSION=${MYSQL_VERSION} .
 
 ## Post build unit tests
 
@@ -11,7 +11,7 @@ docker stop tcm_mysql_test || true
 docker rm tcm_mysql_test || true
 
 function startMySql() {
-  docker run -d --name=tcm_mysql_test --tmpfs /var/lib/mysql -e MYSQL_ROOT_PASSWORD=foo "$@" thecodingmachine/mysql:${MYSQL_VERSION}-v1
+  docker run -d --name=tcm_mysql_test --tmpfs /var/lib/mysql -e MYSQL_ROOT_PASSWORD=foo "$@" thecodingmachine/mysql:${MYSQL_VERSION}-v2
 }
 
 function stopMySql() {
@@ -61,13 +61,12 @@ startMySql -e STARTUP_COMMAND_1='mysql -uroot -pfoo -e "CREATE DATABASE IF NOT E
 # wait for the scripts to be applied and database to go in main mode
 sleep 10;
 execSql "SHOW DATABASES;"
+docker logs tcm_mysql_test
 execSql "SHOW DATABASES;"  | grep "foobar"
 stopMySql
 
 if [[ "$EVENT_NAME" == "push" || "$EVENT_NAME" == "schedule" ]]; then
-  # Disabling ARM64 build because not available in Debian
-  #docker buildx build --platform=linux/amd64,linux/arm64 --push -t thecodingmachine/mysql:${MYSQL_VERSION}-v1 --build-arg MYSQL_VERSION=${MYSQL_VERSION} .
-  docker buildx build --platform=linux/amd64 --push -t thecodingmachine/mysql:${MYSQL_VERSION}-v1 --build-arg MYSQL_VERSION=${MYSQL_VERSION} .
+  docker buildx build --platform=linux/amd64,linux/arm64 --push -t thecodingmachine/mysql:${MYSQL_VERSION}-v2 --build-arg MYSQL_VERSION=${MYSQL_VERSION} .
 fi
 
 #startMySql -e MYSQL_INI_MAX_ALLOWED_PACKET=64M


### PR DESCRIPTION
This allows building for ARM too

This creates a new v2 image for thecodingmachine/mysql (because Oracle instead of Debian is clearly a breaking change)